### PR TITLE
fix edge case for in-row cells.

### DIFF
--- a/core/src/main/scala/chandu0101/scalajs/react/components/ReactTable.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/ReactTable.scala
@@ -215,12 +215,12 @@ case class ReactTable[T](data: Seq[T],
         val existsRowSeq = configs.exists(_.rowSeq.isDefined)
         val rowSpan = configs.flatMap(_.rowSeq.map(_ (model).size).toList)
         val tds = props.configs.map { config =>
-          if (config.rowSeq.isEmpty) {
+          if (config.rowSeq.isEmpty || config.rowSeq.exists(f => f(model).isEmpty)) {
             Seq(
               <.td(^.whiteSpace.nowrap.when(config.nowrap),
                 ^.key := config.name,
                 ^.verticalAlign.middle,
-                (^.rowSpan := rowSpan.max).when(existsRowSeq),
+                (^.rowSpan := rowSpan.max).when(existsRowSeq && rowSpan.max > 0),
                 config.cellRenderer(model)
               )
             ).zipWithIndex
@@ -230,8 +230,8 @@ case class ReactTable[T](data: Seq[T],
                 ^.verticalAlign.middle,
                 ^.key := config.name,
                 node)
-            }
-          }.zipWithIndex
+            }.zipWithIndex
+          }
         }
 
         val maxIndex = tds.flatMap(_.map(_._2)).max


### PR DESCRIPTION
Sorry for my mistake. 
Previous [PR](https://github.com/chandu0101/scalajs-react-components/pull/101) handles only the situation that in-row cells is not empty. When empty, it will be wierd in the table.

This fix the issue. Now empty cells here is also OK now.
![image](https://user-images.githubusercontent.com/6812513/38227612-9cee0248-3731-11e8-958a-170fd1799154.png)
